### PR TITLE
[feat] front 로그인 페이지 구현

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,99 +1,34 @@
 # import os
-import time
 
 # import requests
 import streamlit as st
 from pyparsing import empty
-from utils import show_img
+from utils import init_session_state
 
 st.set_page_config(layout="wide")
 empty1, con1, empty2 = st.columns([0.2, 1.2, 0.2])  # title
 empty1, con2, empty2 = st.columns([0.2, 1.2, 0.2])  # text input
-empty1, con3, con4, con5, empty2 = st.columns([0.2, 0.4, 0.4, 0.4, 0.2])  # image
-empty1, con6, empty2 = st.columns([0.2, 1.2, 0.2])  # ment
-empty1, con7, _, con8, empty2 = st.columns([0.2, 0.2, 0.85, 0.2, 0.2])  # two button
+empty1, con3, empty2 = st.columns([0.2, 1.2, 0.2])  # text input
+empty1, con4, empty2 = st.columns([0.2, 1.2, 0.2])  # text input
+
+sample_user = {"id": "123", "passward": "123"}
 
 
 def main():
-    if "prompt" not in st.session_state:
-        st.session_state.prompt = ""
-    if "user_id" not in st.session_state:
-        st.session_state.user_id = "temp"
-    if "img_select" not in st.session_state:
-        st.session_state.img_select = ""
-    if "item_select" not in st.session_state:
-        st.session_state.item_select = {}
-    if "img_gen" not in st.session_state:
-        st.session_state.img_gen = 1
+    init_session_state()
+    print(st.session_state)
 
     with empty1:
         empty()
     with con1:
-        st.header(f"{st.session_state.user_id}님 반갑습니다.")
+        st.header("Login")
     with con2:
-        new = st.text_area("상품에 대한 간략한 설명을 입력해주세요. ( 입력 후, cmd(ctrl)+enter ) ")
-        st.session_state.prompt = new.strip() if st.session_state.img_gen else st.session_state.prompt.strip()
-    if len(st.session_state.prompt) > 0 and st.session_state.img_gen:
-        with con2:
-            st.write("이미지를 생성합니다.(최대 1분 소요)")
-        time.sleep(5)
-        # datas = {"prompt": st.session_state.prompt, "user_id": st.session_state.user_id}
-        # response = requests.post(os.environ["url"] + "imaggen", data=datas).json()
-        # if response.status_code == 200:
-        #     images = response["images"]
-        st.session_state.img_gen = 0
-    if len(st.session_state.prompt) >= 5:
-        images = [
-            {"image_id": "img1", "image_url": "https://bit.ly/3JM8yqL"},
-            {
-                "image_id": "img2",
-                "image_url": "https://bit.ly/3JOlMTL",
-            },
-            {
-                "image_id": "img3",
-                "image_url": "https://bit.ly/4bI0xPB",
-            },
-        ]
-    elif 0 < len(st.session_state.prompt) < 5:
-        images = [
-            {
-                "image_id": "img2",
-                "image_url": "https://bit.ly/3wqL875",
-            }
-            for _ in range(3)
-        ]
-    elif len(st.session_state.prompt) == 0:
-        images = [
-            {
-                "image_id": "no_img",
-                "image_url": "https://bit.ly/3WonhQ5",
-            }
-            for _ in range(3)
-        ]
-        st.session_state.img_gen = 1
+        st.session_state.user_id = st.text_input("Username")
+        passward = st.text_input("Passward")
     with con3:
-        show_img(images[0]["image_id"], images[0]["image_url"])
-    with con4:
-        show_img(images[1]["image_id"], images[1]["image_url"])
-    with con5:
-        show_img(images[2]["image_id"], images[2]["image_url"])
-    with con6:
-        if images[0]["image_id"] != "no_img":
-            st.session_state.img_select = st.selectbox(
-                f"< {st.session_state.prompt} > 에 대한 결과입니다.  마음에 드는 이미지를 선택하세요.",
-                (images[0]["image_id"], images[1]["image_id"], images[2]["image_id"]),
-            )
-            # st.write(st.session_state.img_select, "선택됨")
-        else:
-            st.write("상품 설명을 입력하고 이미지를 생성하세요!")
-    with con7:
-        if images[0]["image_id"] != "no_img":
-            if st.button("이미지 재생성"):
-                st.session_state.img_gen = 1
-                st.rerun()
-    with con8:
-        if st.session_state.img_select in (images[0]["image_id"], images[1]["image_id"], images[2]["image_id"]):
-            st.page_link(page="./pages/recommend.py", label="다음 페이지", icon="➡️")
+        if st.button("Login"):
+            if st.session_state.user_id == sample_user["id"] and passward == sample_user["passward"]:
+                st.switch_page("./pages/image.py")
     with empty2:
         empty()
 

--- a/frontend/pages/image.py
+++ b/frontend/pages/image.py
@@ -1,0 +1,100 @@
+# import os
+import time
+
+# import requests
+import streamlit as st
+from pyparsing import empty
+from utils import show_img
+
+st.set_page_config(layout="wide")
+empty1, con1, empty2 = st.columns([0.2, 1.2, 0.2])  # title
+empty1, con2, empty2 = st.columns([0.2, 1.2, 0.2])  # text input
+empty1, con3, con4, con5, empty2 = st.columns([0.2, 0.4, 0.4, 0.4, 0.2])  # image
+empty1, con6, empty2 = st.columns([0.2, 1.2, 0.2])  # ment
+empty1, con7, _, con8, empty2 = st.columns([0.2, 0.2, 0.85, 0.2, 0.2])  # two button
+empty1, con9, empty2 = st.columns([0.725, 0.15, 0.725])
+
+
+def main():
+    print(st.session_state)
+    if st.session_state.user_id == "":
+        st.switch_page("./app.py")
+    with empty1:
+        empty()
+    with con1:
+        st.header(f"{st.session_state.user_id}님 반갑습니다.")
+    with con2:
+        new = st.text_area("상품에 대한 간략한 설명을 입력해주세요. ( 입력 후, cmd(ctrl)+enter ) ")
+        st.session_state.prompt = new.strip() if st.session_state.img_gen else st.session_state.prompt.strip()
+    if len(st.session_state.prompt) > 0 and st.session_state.img_gen:
+        with con2:
+            st.write("이미지를 생성합니다.(최대 1분 소요)")
+        time.sleep(5)
+        # datas = {"prompt": st.session_state.prompt, "user_id": st.session_state.user_id}
+        # response = requests.post(os.environ["url"] + "imaggen", data=datas).json()
+        # if response.status_code == 200:
+        #     images = response["images"]
+        st.session_state.img_gen = 0
+    if len(st.session_state.prompt) >= 5:
+        images = [
+            {"image_id": "img1", "image_url": "https://bit.ly/3JM8yqL"},
+            {
+                "image_id": "img2",
+                "image_url": "https://bit.ly/3JOlMTL",
+            },
+            {
+                "image_id": "img3",
+                "image_url": "https://bit.ly/4bI0xPB",
+            },
+        ]
+    elif 0 < len(st.session_state.prompt) < 5:
+        images = [
+            {
+                "image_id": "img2",
+                "image_url": "https://bit.ly/3wqL875",
+            }
+            for _ in range(3)
+        ]
+    elif len(st.session_state.prompt) == 0:
+        images = [
+            {
+                "image_id": "no_img",
+                "image_url": "https://bit.ly/3WonhQ5",
+            }
+            for _ in range(3)
+        ]
+        st.session_state.img_gen = 1
+    with con3:
+        show_img(images[0]["image_id"], images[0]["image_url"])
+    with con4:
+        show_img(images[1]["image_id"], images[1]["image_url"])
+    with con5:
+        show_img(images[2]["image_id"], images[2]["image_url"])
+    with con6:
+        if images[0]["image_id"] != "no_img":
+            st.session_state.img_select = st.selectbox(
+                f"< {st.session_state.prompt} > 에 대한 결과입니다.  마음에 드는 이미지를 선택하세요.",
+                (images[0]["image_id"], images[1]["image_id"], images[2]["image_id"]),
+            )
+            # st.write(st.session_state.img_select, "선택됨")
+        else:
+            st.write("상품 설명을 입력하고 이미지를 생성하세요!")
+    with con7:
+        if images[0]["image_id"] != "no_img":
+            if st.button("이미지 재생성"):
+                st.session_state.img_gen = 1
+                st.rerun()
+    with con8:
+        if st.session_state.img_select in (images[0]["image_id"], images[1]["image_id"], images[2]["image_id"]):
+            st.page_link(page="./pages/recommend.py", label="다음 페이지", icon="➡️")
+    with con9:
+        st.header("")
+        st.header("")
+        if st.button("Logout"):
+            st.switch_page("./app.py")
+    with empty2:
+        empty()
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/pages/recommend.py
+++ b/frontend/pages/recommend.py
@@ -11,6 +11,7 @@ empty1, con1, con2, con3, con4, con5, empty2 = st.columns([0.1, 0.4, 0.4, 0.4, 0
 empty1, con6, con7, con8, con9, con10, empty2 = st.columns([0.1, 0.4, 0.4, 0.4, 0.4, 0.4, 0.1])  # item6-10
 empty1, con11, empty2 = st.columns([0.1, 2.0, 0.1])  # empty limne
 empty1, con12, _, con13, empty2 = st.columns([0.1, 0.15, 1.6, 0.25, 0.1])  # two button
+empty1, con14, empty2 = st.columns([0.725, 0.15, 0.725])  # two button
 
 
 temp_data = {
@@ -21,6 +22,8 @@ temp_data = {
 
 
 def main():
+    if st.session_state.user_id == "":
+        st.switch_page("./app.py")
     with empty1:
         empty()
     # datas = {"image_id": st.session_state.img_select, "user_id": st.session_state.user_id}
@@ -74,9 +77,15 @@ def main():
             st.session_state.prompt = ""
             st.session_state.img_select = ""
             st.session_state.img_gen = 1
-            st.page_link(page="./app.py", label="처음으로", icon="🏠")
+            st.page_link(page="./pages/image.py", label="처음으로", icon="🏠")
         with con13:
             st.page_link(page="./pages/result.py", label="다음 페이지", icon="➡️")
+        with con14:
+            st.header("")
+            st.header("")
+
+            if st.button("Logout"):
+                st.switch_page("./app.py")
     with empty2:
         empty()
 

--- a/frontend/pages/result.py
+++ b/frontend/pages/result.py
@@ -9,10 +9,13 @@ st.set_page_config(layout="wide")
 empty1, con0, empty2 = st.columns([0.1, 0.15, 0.1])
 empty1, con1, empty2 = st.columns([0.1, 0.3, 0.1])
 empty1, line, empty2 = st.columns([0.1, 0.3, 0.1])
-empty1, _, con2, empty2 = st.columns([0.2, 1.5, 0.2, 0.2])  # two button
+empty1, _, con2, empty2 = st.columns([0.2, 1.5, 0.2, 0.2])
+empty1, con3, empty2 = st.columns([0.725, 0.15, 0.725])
 
 
 def main():
+    if st.session_state.user_id == "":
+        st.switch_page("./app.py")
     with empty1:
         empty()
     print(st.session_state.item_select)
@@ -27,14 +30,17 @@ def main():
         st.write(f"상품 분류 : {st.session_state.item_select['prod_type_name']}")
         st.write(f"상품 설명 : {st.session_state.item_select['detail_desc']}")
     with line:
-        st.write()
-        st.write()
-        st.write()
+        st.header("")
     with con2:
         st.session_state.prompt = ""
         st.session_state.img_select = ""
         st.session_state.img_gen = 1
-        st.page_link(page="./app.py", label="처음으로", icon="🏠")
+        st.page_link(page="./pages/image.py", label="처음으로", icon="🏠")
+    with con3:
+        st.header("")
+        st.header("")
+        if st.button("Logout"):
+            st.switch_page("./app.py")
     with empty2:
         empty()
 

--- a/frontend/utils.py
+++ b/frontend/utils.py
@@ -21,3 +21,11 @@ def show_item(item_info):
             st.markdown(f"상품 이름 : {item_info['prod_name']}")
             st.markdown(f"상품 분류 : {item_info['prod_type_name']}")
             st.markdown(f"상품 설명 : {item_info['detail_desc']}")
+
+
+def init_session_state():
+    st.session_state.prompt = ""
+    st.session_state.user_id = ""
+    st.session_state.img_select = ""
+    st.session_state.item_select = {}
+    st.session_state.img_gen = 1


### PR DESCRIPTION
#### 구현 내용
- 로그인 페이지 구현
- 로그인 추가되며 필요한 기능 추가 (로그아웃 / 로그인 상태인 경우만 다른 페이지로 갈 수 있도록 제한 / 세션 데이터 초기화)
<img width="500" alt="Screenshot 2024-05-08 at 02 19 46" src="https://github.com/lijm1358/Grad_proj_service/assets/118340911/e1ead60f-4d36-4f52-996a-239ac89b542a">
<img width="500" alt="Screenshot 2024-05-08 at 02 20 00" src="https://github.com/lijm1358/Grad_proj_service/assets/118340911/0bf90a4c-7a72-4187-9189-74f78efa9732">



#### 코멘트
- 이상 없이 동작하는 것 확인했습니다.
- 현재 샘플 데이터를 통해 로그인 인증하고 있는데 이를 DB 연결 후 수정할 필요가 있습니다.
- 머지 후 브랜치는 지워주세요~!!
