### PR TITLE
[fix] bump SQLAlchemy from 1.4.52 to 2.0.30

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -273,7 +273,7 @@ shortuuid==1.0.13
 six @ file:///home/conda/feedstock_root/build_artifacts/six_1620240208055/work
 smmap==5.0.1
 sniffio==1.3.1
-SQLAlchemy==1.4.52
+SQLAlchemy==2.0.30
 sqlalchemy-bigquery==1.11.0
 SQLAlchemy-JSONField==1.0.2
 sqlalchemy-spanner==1.7.0


### PR DESCRIPTION
* Airflow(아래 참조)와 SQLModel(`sqlalchemy>=2.0`)이 요구하는 SQLAlchemy version이 다름
```
apache-airflow 2.9.1 has requirement sqlalchemy<2.0,>=1.4.36, but you have sqlalchemy 2.0.30.
flask-appbuilder 4.4.1 has requirement SQLAlchemy<1.5, but you have sqlalchemy 2.0.30.
marshmallow-sqlalchemy 0.28.2 has requirement SQLAlchemy<2.0,>=1.3.0, but you have sqlalchemy 2.0.30.
```
* Airflow는 docker container에서 작동하기 때문에 package 설치 필요가 없고, IDE에서의 자동완성 등 단순히 개발용으로만 패키지 설치
* SQLModel은 backend 서버 동작에 필요함